### PR TITLE
Mysql command fails with empty password parameter

### DIFF
--- a/Classes/M12/DbExport/Command/DbCommandController.php
+++ b/Classes/M12/DbExport/Command/DbCommandController.php
@@ -171,7 +171,10 @@ class DbCommandController extends CommandController {
 		$user = isset($this->backendOptions['user']) ? $this->backendOptions['user'] : 'root';
 		$pass = isset($this->backendOptions['password']) ? $this->backendOptions['password'] : '';
 		$port = isset($this->backendOptions['port']) ? $this->backendOptions['port'] : 3306;
-		return " -h{$host} -u{$user} -p{$pass} -P{$port}";
+		if (!empty($pass)) {
+			return " -h{$host} -u{$user} -p{$pass} -P{$port}";
+		}
+		return " -h{$host} -u{$user} -P{$port}";
 	}
 
 	/**


### PR DESCRIPTION
On my localhost I don't have any password for mysql set. If I don't specify a password as parameter, mysql still expects one to be set.
